### PR TITLE
Fix text format loading

### DIFF
--- a/pycolmap/scene_manager.py
+++ b/pycolmap/scene_manager.py
@@ -195,12 +195,13 @@ class SceneManager:
                 if is_camera_description_line:
                     image_id = int(data[0])
                     image = Image(data[-1], int(data[-2]),
-                                  Quaternion(np.array(map(float, data[1:5]))),
-                                  np.array(map(float, data[5:8])))
+                                  Quaternion(np.array([float(x) for x in data[1:5]])),
+                                  np.array([float(x) for x in data[5:8]]))
                 else:
                     image.points2D = np.array(
-                        [map(float, data[::3]), map(float, data[1::3])]).T
-                    image.point3D_ids = np.array(map(np.uint64, data[2::3]))
+                        [[float(x) for x in data[::3]], [float(x) for x in data[1::3]]]
+                    ).T
+                    image.point3D_ids = np.array([np.uint64(x) for x in data[2::3]])
 
                     # automatically remove points without an associated 3D point
                     #mask = (image.point3D_ids != SceneManager.INVALID_POINT3D)
@@ -272,13 +273,13 @@ class SceneManager:
 
                 self.point3D_ids.append(point3D_id)
                 self.point3D_id_to_point3D_idx[point3D_id] = len(self.points3D)
-                self.points3D.append(map(np.float64, data[1:4]))
-                self.point3D_colors.append(map(np.uint8, data[4:7]))
+                self.points3D.append([np.float64(x) for x in data[1:4]])
+                self.point3D_colors.append([np.uint8(x) for x in data[4:7]])
                 self.point3D_errors.append(np.float64(data[7]))
 
                 # load (image id, point2D idx) pairs
                 self.point3D_id_to_images[point3D_id] = \
-                    np.array(map(np.uint32, data[8:])).reshape(-1, 2)
+                    np.array([np.uint32(x) for x in data[8:]]).reshape(-1, 2)
 
         self.points3D = np.array(self.points3D)
         self.point3D_ids = np.array(self.point3D_ids)


### PR DESCRIPTION
Replaced map() with list comprehension - numpy creates an array with map object when calling `np.array(map(...))` because map is an iterator, not sequence. See https://stackoverflow.com/questions/28524378/convert-map-object-to-numpy-array-in-python-3